### PR TITLE
roundtripmeasurement.py: Close server without exception

### DIFF
--- a/roundtripmeasurement.py
+++ b/roundtripmeasurement.py
@@ -7,6 +7,7 @@ import socket
 import multiprocessing
 import time
 import pickle
+import sys
 
 class RoundTripMeasurement(measurement.Measurement):
 
@@ -60,12 +61,17 @@ latencies of each packet received back from the server."""
         print("UDP server running...")
 
         while True:
-            data, recv_addr = sock_in.recvfrom(recv_buffer_size)
-            if not data:
+            try:
+                data, recv_addr = sock_in.recvfrom(recv_buffer_size)
+                if not data:
+                    break
+                send_addr = (recv_addr[0], listen_port + 1)
+                sock_out.sendto(data, send_addr)
+            except KeyboardInterrupt:
                 break
-            send_addr = (recv_addr[0], listen_port + 1)
-            sock_out.sendto(data, send_addr)
+        print("Closing...")
         sock_out.close()
+        sys.exit(0)
 
     @classmethod
     def get_packet_payload(cls, packet_n):


### PR DESCRIPTION
First of all, great job!!!

The commit avoid the following problem when you close the server:

```
^CTraceback (most recent call last):
  File "./echo.py", line 26, in <module>
    common.main(roundtripmeasurement.RoundTripMeasurement)
  File "/home/lander/ultra_ping/common.py", line 25, in main
    tester.run_server(args.listen_port, SERVER_RECV_BUFFER_SIZE)
  File "/home/lander/ultra_ping/roundtripmeasurement.py", line 63, in run_server
    data, recv_addr = sock_in.recvfrom(recv_buffer_size)
KeyboardInterrupt
```